### PR TITLE
Gradle publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing
+
+## Steps
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request
+
+## Publishing
+
+We publish our Java SDK to Bintray's JCenter and Sonatype's Central Repository.  
+That process is not automated yet and it requires to have special access, but here's the steps:
+
+### 1. Dry run
+* Set the following environment variables:
+```bash
+export SONATYPE_USER="<secret>"
+export SONATYPE_PASSWORD="<secret>"
+export BINTRAY_USER="<secret>"
+export BINTRAY_KEY="<secret>"
+```
+* Adjust the VERSION variable in the following files:
+	* `discovery/gradle.properties`
+	* `discovery-model/gradle.properties` 
+* Run: 
+```
+./gradlew clean install bintrayUpload -i
+```
+
+### 2. Publishing
+**If the dry run went well, you can proceed**  
+
+* Set the following environment variables:
+
+```bash
+export SONATYPE_USER="<secret>"
+export SONATYPE_PASSWORD="<secret>"
+export BINTRAY_USER="<secret>"
+export BINTRAY_KEY="<secret>"
+export BINTRAY_DRYRUN=0
+export SONATYPE_CLOSE=1
+```
+
+* Run: 
+```
+./gradlew clean install bintrayUpload -i
+```
+* Validate that everything is successfully published to JCenter and the Central Repository (it can take some times)

--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@
 Detailed information about the APIs can be found here:  
 http://developer.ticketmaster.com/
 
-## Basic Usage
+## Usage
+
+### Basic Usage
 
 ```java
 String apikey = "<YOUR KEY>";
-DiscoveryApi api = DiscoveryApi.builder(apikey).build();
+DiscoveryApi api = new DiscoveryApi(apikey);
 
-PagedResponse<Events> page = api.searchEvents(SearchEventsOperation.builder().keyword("<SEARCH TERM>").build());
+PagedResponse<Events> page = api.searchEvents(new SearchEventsOperation().keyword("<SEARCH TERM>"));
 List<Event> events = page.getContent().getEvents();
 ```
 
-## Rate Limit
+### Rate Limit
 
 The Rate Limit information documented [here](http://developer.ticketmaster.com/products-and-docs/apis/getting-started/) can be retrieved using:
 ```java
@@ -26,5 +28,9 @@ RateLimit rateLimit = response.getRateLimit();
 
 ## Android compatibility
  
- The compatibility with Android was not tested yet, but most of the dependencies seems to be compatible with Android.  
- Feel free to open issues and pull requests.
+Although the compatibility with Android is not fully tested yet, we choose to use Java 7 and compatible dependencies.     
+Feel free to open issues and pull requests regarding that.
+
+## Contributing
+
+Please check out [this page](../blob/master/CONTRIBUTING.md)

--- a/build.gradle
+++ b/build.gradle
@@ -1,22 +1,62 @@
-plugins {
-  id "nebula.provided-base" version "3.0.3"
+buildscript {
+    repositories {
+        mavenCentral()
+        jcenter()
+    }
+
+    dependencies {
+        //Check for the latest version here: http://plugins.gradle.org/plugin/com.jfrog.artifactory
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:3.0.3"
+        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"
+        classpath "com.netflix.nebula:gradle-extra-configurations-plugin:3.0.3"
+    }
 }
-
-
 subprojects {
-  apply plugin: "java"
+  apply plugin: 'java'
+  apply plugin: 'nebula.optional-base'
   apply plugin: 'nebula.provided-base'
   
-  sourceCompatibility = 1.7
-  targetCompatibility = 1.7
+  targetCompatibility = "1.7"
+  sourceCompatibility = "1.7"
   
   repositories {
-    mavenCentral()
+      mavenCentral()
+      jcenter()
+  }
+
+  task javadocJar(type: Jar, dependsOn: javadoc) {
+      classifier = 'javadoc'
+      from 'build/docs/javadoc'
+  }
+  
+  task sourcesJar(type: Jar) {
+      from sourceSets.main.allSource
+      classifier = 'sources'
+  }
+  
+  artifacts {
+      archives jar
+      archives javadocJar
+      archives sourcesJar
   }
 }
 
-project(':discovery') {
+
+project(':discovery-java') {
     dependencies {
-        compile project(':discovery-model')
+        compile project(':discovery-model-java')
     }
+}
+
+// Adding a Help task to debug the artifacts 
+task artifacts {
+  group = "Help"
+  description = "Displays the artifacts associated with each configuration of " + project
+  doFirst {
+    configurations.findAll().each { config ->
+      println "${config}:"
+      config.allArtifacts.getFiles().each { file -> println "" + file}
+      println ' '
+    }
+  }
 }

--- a/discovery-model/build.gradle
+++ b/discovery-model/build.gradle
@@ -1,9 +1,15 @@
-dependencies {
-	compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.0'
-	compile 'joda-time:joda-time:2.9.2'
-
-	provided 'org.projectlombok:lombok:1.16.6'
-
-	testCompile 'junit:junit:4.12'
-	testCompile 'org.assertj:assertj-core:2.4.1'
+plugins {
+    id "com.jfrog.bintray" version "1.6"
 }
+
+dependencies {
+  compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.0'
+  compile 'joda-time:joda-time:2.9.2'
+
+  provided 'org.projectlombok:lombok:1.16.6'
+
+  testCompile 'junit:junit:4.12'
+  testCompile 'org.assertj:assertj-core:2.4.1'
+}
+  
+apply from: '../gradle/publishing.gradle'

--- a/discovery-model/gradle.properties
+++ b/discovery-model/gradle.properties
@@ -1,0 +1,14 @@
+VERSION=0.0.1-alpha-2
+
+GROUP_ID=com.ticketmaster.api
+DESCRIPTION=Ticketmaster Discovery Model - Java
+WEBSITE_URL=http://developer.ticketmaster.com
+SCM_CONNECTION=scm:git:git://github.com/ticketmaster-api/sdk-java.git
+SCM_DEVELOPER=scm:git:ssh://git@github.com/ticketmaster-api/sdk-java.git
+SCM_URL=https://github.com/ticketmaster-api/sdk-java
+GITHUB_REPO=ticketmaster-api/sdk-java
+LICENSE_NAME=The MIT License (MIT)
+LICENSE_URL=https://opensource.org/licenses/mit-license.php
+DEVELOPER_ID=ledor473
+DEVELOPER_NAME=Louis-Etienne Dorval
+DEVELOPER_EMAIL=louis-etienne.dorval@ticketmaster.com

--- a/discovery-model/settings.gradle
+++ b/discovery-model/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "discovery-model-java"

--- a/discovery/build.gradle
+++ b/discovery/build.gradle
@@ -1,15 +1,20 @@
-dependencies {
-	compile 'com.squareup.okhttp3:okhttp:3.1.2'
-	compile 'com.fasterxml.jackson.core:jackson-core:2.7.0'
-	compile 'com.fasterxml.jackson.core:jackson-databind:2.7.0'
-	compile 'com.fasterxml.jackson.datatype:jackson-datatype-guava:2.7.0'
-	compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.7.0'
-	compile 'joda-time:joda-time:2.9.2'
-	compile 'org.slf4j:slf4j-api:1.7.16'
-
-	provided 'org.projectlombok:lombok:1.16.6'
-
-	testCompile 'junit:junit:4.12'
-	testCompile 'org.assertj:assertj-core:2.4.1'
-	testCompile 'org.slf4j:slf4j-log4j12:1.7.16'
+plugins {
+    id "com.jfrog.bintray" version "1.6"
 }
+
+dependencies {
+       compile 'com.squareup.okhttp3:okhttp:3.1.2'
+       compile 'com.fasterxml.jackson.core:jackson-core:2.7.0'
+       compile 'com.fasterxml.jackson.core:jackson-databind:2.7.0'
+       compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.7.0'
+       compile 'joda-time:joda-time:2.9.2'
+       compile 'org.slf4j:slf4j-api:1.7.16'
+
+       provided 'org.projectlombok:lombok:1.16.6'
+
+       testCompile 'junit:junit:4.12'
+       testCompile 'org.assertj:assertj-core:2.4.1'
+       testCompile 'org.slf4j:slf4j-log4j12:1.7.16'
+}
+  
+apply from: '../gradle/publishing.gradle'

--- a/discovery/gradle.properties
+++ b/discovery/gradle.properties
@@ -1,0 +1,14 @@
+VERSION=0.0.1-alpha-2
+
+GROUP_ID=com.ticketmaster.api
+DESCRIPTION=Ticketmaster Discovery API SDK - Java
+WEBSITE_URL=http://developer.ticketmaster.com
+SCM_CONNECTION=scm:git:git://github.com/ticketmaster-api/sdk-java.git
+SCM_DEVELOPER=scm:git:ssh://git@github.com/ticketmaster-api/sdk-java.git
+SCM_URL=https://github.com/ticketmaster-api/sdk-java
+GITHUB_REPO=ticketmaster-api/sdk-java
+LICENSE_NAME=The MIT License (MIT)
+LICENSE_URL=https://opensource.org/licenses/mit-license.php
+DEVELOPER_ID=ledor473
+DEVELOPER_NAME=Louis-Etienne Dorval
+DEVELOPER_EMAIL=louis-etienne.dorval@ticketmaster.com

--- a/discovery/settings.gradle
+++ b/discovery/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "discovery-java"

--- a/gradle/publishing-jcenter.gradle
+++ b/gradle/publishing-jcenter.gradle
@@ -1,0 +1,44 @@
+//
+// Artifactory
+// ./gradlew bintrayUpload (upload release to JCenter)
+//
+apply plugin: 'com.jfrog.bintray'
+
+Properties properties = new Properties()
+try {
+    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+} catch (FileNotFoundException ignore) {}
+
+group = GROUP_ID
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_KEY')
+    publications = [ "_${project.name}_" ]
+    pkg {
+        repo = 'maven'
+        name = project.name
+        userOrg = 'ticketmaster-api'
+        desc = DESCRIPTION
+        websiteUrl = WEBSITE_URL
+        vcsUrl = SCM_URL
+        githubRepo = GITHUB_REPO
+        licenses = [ LICENSE_NAME ]
+        publicDownloadNumbers = true
+        publish = true
+        dryRun = System.getenv('BINTRAY_DRYRUN') != null ? System.getenv('BINTRAY_DRYRUN') : false 
+        version {
+            name = VERSION
+            gpg {
+                // Without this, .asc files don't get generated
+                sign = true
+            }
+            mavenCentralSync {
+                sync = true
+                user = System.getenv('SONATYPE_USER')
+                password = System.getenv('SONATYPE_PASSWORD')
+                close = System.getenv('SONATYPE_CLOSE') != null ? System.getenv('SONATYPE_CLOSE') : '0'
+            }       
+        }
+    }
+}

--- a/gradle/publishing-jcenter.gradle
+++ b/gradle/publishing-jcenter.gradle
@@ -26,7 +26,7 @@ bintray {
         licenses = [ LICENSE_NAME ]
         publicDownloadNumbers = true
         publish = true
-        dryRun = System.getenv('BINTRAY_DRYRUN') != null ? System.getenv('BINTRAY_DRYRUN') : false 
+        dryRun = System.getenv('BINTRAY_DRYRUN') != null ? System.getenv('BINTRAY_DRYRUN') : true 
         version {
             name = VERSION
             gpg {

--- a/gradle/publishing-maven.gradle
+++ b/gradle/publishing-maven.gradle
@@ -1,0 +1,46 @@
+apply plugin: 'maven-publish'
+apply plugin: 'maven'
+
+version = VERSION
+
+// Customizing the generated pom.xml to comply with the requirement from Maven Central
+publishing {
+    publications {
+        "_${project.name}_"(MavenPublication) {
+            groupId GROUP_ID
+            artifactId project.name
+            
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+            
+            pom.withXml {
+                asNode().children().last() + {
+                    resolveStrategy = Closure.DELEGATE_FIRST
+                    name project.name
+                    description DESCRIPTION
+                    url WEBSITE_URL
+                    scm {
+                        connection SCM_CONNECTION
+                        developerConnection SCM_DEVELOPER
+                        url SCM_URL
+                    }
+                    licenses {
+                        license {
+                            name LICENSE_NAME
+                            url LICENSE_URL
+                            distribution 'repo'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id DEVELOPER_ID
+                            name DEVELOPER_NAME
+                            email DEVELOPER_EMAIL
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,0 +1,19 @@
+apply plugin: 'signing'
+
+javadoc {
+    failOnError false
+}
+
+buildscript {
+    repositories {
+        jcenter()
+
+    }
+    dependencies {
+        //Check for the latest version here: http://plugins.gradle.org/plugin/com.jfrog.artifactory
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:3.0.3"
+    }
+}
+
+apply from: '../gradle/publishing-maven.gradle'
+apply from: '../gradle/publishing-jcenter.gradle'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 include 'discovery', 'discovery-model'
+project(":discovery").name = "discovery-java"
+project(":discovery-model").name = "discovery-model-java"


### PR DESCRIPTION
Maven publication (to Bintray synced back to Sonatype) is now working for discovery-java and discovery-model-java
