### PR TITLE
Make sure okhttp3.ResponseBody is always closed.

### DIFF
--- a/discovery-model/gradle.properties
+++ b/discovery-model/gradle.properties
@@ -1,4 +1,4 @@
-VERSION=0.1.6
+VERSION=0.1.7
 
 GROUP_ID=com.ticketmaster.api
 DESCRIPTION=Ticketmaster Discovery Model - Java

--- a/discovery/gradle.properties
+++ b/discovery/gradle.properties
@@ -1,4 +1,4 @@
-VERSION=0.1.6
+VERSION=0.1.7
 
 GROUP_ID=com.ticketmaster.api
 DESCRIPTION=Ticketmaster Discovery API SDK - Java

--- a/discovery/src/main/java/com/ticketmaster/api/Version.java
+++ b/discovery/src/main/java/com/ticketmaster/api/Version.java
@@ -2,7 +2,7 @@ package com.ticketmaster.api;
 
 public class Version {
 
-  public static final String SDK_VERSION = "0.1.6";
+  public static final String SDK_VERSION = "0.1.7";
 
   public static final String getUserAgent() {
     return "Ticketmaster Discovery Java SDK/" + SDK_VERSION;

--- a/discovery/src/main/java/com/ticketmaster/api/discovery/response/PagedResponse.java
+++ b/discovery/src/main/java/com/ticketmaster/api/discovery/response/PagedResponse.java
@@ -13,7 +13,7 @@ public class PagedResponse<T> extends Response<T> {
   private final JavaType javaType;
   private Page<T> page;
 
-  public PagedResponse(okhttp3.Response httpResponse, ObjectMapper mapper, Class<T> type) {
+  public PagedResponse(okhttp3.Response httpResponse, ObjectMapper mapper, Class<T> type) throws IOException {
     super(httpResponse, mapper, type);
     this.javaType = mapper.getTypeFactory().constructParametricType(Page.class, type);
   }

--- a/discovery/src/main/java/com/ticketmaster/api/discovery/response/Response.java
+++ b/discovery/src/main/java/com/ticketmaster/api/discovery/response/Response.java
@@ -17,17 +17,20 @@ public class Response<T> {
   protected T content;
   protected String jsonPayload;
 
-  public Response(okhttp3.Response httpResponse, ObjectMapper mapper, Class<T> type) {
+  public Response(okhttp3.Response httpResponse, ObjectMapper mapper, Class<T> type) throws IOException {
     this.rateLimit = new RateLimit(httpResponse);
     this.mapper = mapper;
     this.type = type;
     this.httpResponse = httpResponse;
+
+    // The okhttp3.ResponseBody in the httpResponse must always be closed or it is a memory leak.
+    // Call readContent() here which effectively makes sure the okhttp3.ResponseBody is closed.
+    // The OkHttp.ResponseBody.string() which is indirectly called as a result of call readContent()
+    // closes the ResponseBody. Reference, https://square.github.io/okhttp/3.x/okhttp/okhttp3/ResponseBody.html.
+    readContent();
   }
 
   public T getContent() throws IOException {
-    if (content == null) {
-      readContent();
-    }
     return content;
   }
 


### PR DESCRIPTION
When Discovery Response.getContent() is not called ( e.g. - when unsuccessful Http status ), the okhttp3.ResponseBody will not get closed. Change semantics of Response so that the okhttp3.ResponseBody is always closed. Otherwise, there is a memory leak. Could have made this change in many ways. Would have preferred to entirely remove containment of okhttp3.Response in the Discovery Response type, but took path of fewest changes.